### PR TITLE
Add support of header only library

### DIFF
--- a/baker/definitions/cc_library.py
+++ b/baker/definitions/cc_library.py
@@ -16,6 +16,9 @@ class CCLibrary(Module):
 
         object = Utils.to_internal_name(name, "OBJ")
         lines.append(f'add_library({object} OBJECT)')
+        # hack for header only library, which is hard to determine whether it contains srcs
+        lines.append(f'target_sources({object} PUBLIC ".")')
+        lines.append(f'set_target_properties({object} PROPERTIES LINKER_LANGUAGE CXX)')
         # Always enable position independent code
         lines.append(f'set_target_properties({object} PROPERTIES POSITION_INDEPENDENT_CODE ON)')
 
@@ -26,10 +29,12 @@ class CCLibrary(Module):
             lines.append(f'add_library({name}-shared SHARED)')
             lines.append(f'target_link_libraries({name}-shared PUBLIC {object})')
             lines.append(f'set_target_properties({name}-shared PROPERTIES PREFIX "" OUTPUT_NAME {Utils.to_cmake_expression(name)})')
+            lines.append(f'set_target_properties({name}-shared PROPERTIES LINKER_LANGUAGE CXX)')
         if not self._module.name.endswith("_shared"):
             lines.append(f'add_library({name}-static STATIC)')
             lines.append(f'target_link_libraries({name}-static PUBLIC {object})')
             lines.append(f'set_target_properties({name}-static PROPERTIES PREFIX "" OUTPUT_NAME {Utils.to_cmake_expression(name)})')
+            lines.append(f'set_target_properties({name}-static PROPERTIES LINKER_LANGUAGE CXX)')
         # Add alias for static only library
         if self._module.name.endswith("_static"):
             lines.append(f'add_library({name} ALIAS {name}-static)')

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -77,7 +77,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
 set(TARGET "linux" ; "glibc"; "host")
 baker(external/fmtlib/)
 baker(system/core/libcutils/)
-
+baker(frameworks/native/libs/math/)
 
 
 # Currently not built by default
@@ -88,6 +88,7 @@ baker(system/core/libutils/ EXCLUDE_FROM_ALL)
 
 # Fix for missing linkage
 set_property(TARGET liblog.defaults APPEND PROPERTY _export_header_libs libutils_headers)
+target_link_libraries(libmath-static PUBLIC libutils_headers)
 
 # fmtlib_test_2 will fail because the locale problem
 set_tests_properties(fmtlib_test_2 DIRECTORY external/fmtlib/ PROPERTIES WILL_FAIL TRUE)

--- a/test/manifest.xml
+++ b/test/manifest.xml
@@ -13,4 +13,6 @@
   <project path="system/libbase" name="platform/system/libbase" groups="pdk" />
   <project path="system/logging" name="platform/system/logging" groups="pdk" />
 
+  <project path="frameworks/native" name="platform/frameworks/native" groups="pdk" />
+
 </manifest>

--- a/test/test.list.txt
+++ b/test/test.list.txt
@@ -5,3 +5,9 @@ fmtlib_test_3
 libcutils_test
 libcutils_test_static
 KernelLibcutilsTest
+
+vec_test
+mat_test
+half_test
+quat_test
+hashcombine_test


### PR DESCRIPTION
CMake library must have sources, otherwise we have to use interface library.
However it is not easy to determine whether the library contains srcs.
So we use hack by adding "." as the sources and set the link language to CXX.