### PR TITLE
Add support of building libcore

### DIFF
--- a/baker/main.py
+++ b/baker/main.py
@@ -65,7 +65,6 @@ def main():
             parent = os.path.dirname(dir_path)
             # When the parent directory do not contain Android.bp, go up to the next directory
             while parent != "" and not os.path.join(root_dir, os.path.join(parent, 'Android.bp')) in blueprint_files:
-                print(dir_path, os.path.abspath(os.path.join(parent, 'Android.bp')))
                 parent = os.path.dirname(parent)
             subdirectories_map.setdefault(parent, []).append(os.path.relpath(dir_path, parent))
 

--- a/baker/main.py
+++ b/baker/main.py
@@ -63,7 +63,11 @@ def main():
         dir_path = os.path.dirname(os.path.relpath(bp_file, root_dir))
         if dir_path != "":
             parent = os.path.dirname(dir_path)
-            subdirectories_map.setdefault(parent, []).append(os.path.basename(dir_path))
+            # When the parent directory do not contain Android.bp, go up to the next directory
+            while parent != "" and not os.path.join(root_dir, os.path.join(parent, 'Android.bp')) in blueprint_files:
+                print(dir_path, os.path.abspath(os.path.join(parent, 'Android.bp')))
+                parent = os.path.dirname(parent)
+            subdirectories_map.setdefault(parent, []).append(os.path.relpath(dir_path, parent))
 
     # Process all identified files
     processed_files = []

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(librustc_demangle_static-static STATIC ".")
 set_target_properties(librustc_demangle_static-static PROPERTIES LINKER_LANGUAGE CXX)
 
 # Most Android.bp add -Werror flags, but create a lot of errors
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w")
 
 set(ARCH "x86_64")
@@ -39,10 +40,13 @@ baker(frameworks/native/libs/math/)
 
 # Currently not built by default
 baker(art/ EXCLUDE_FROM_ALL)
+baker(libcore/ EXCLUDE_FROM_ALL)
 baker(libnativehelper/ EXCLUDE_FROM_ALL)
 baker(external/cpu_features/ EXCLUDE_FROM_ALL)
 baker(external/dlmalloc/ EXCLUDE_FROM_ALL)
+baker(external/fdlibm/ EXCLUDE_FROM_ALL)
 baker(external/googletest/ EXCLUDE_FROM_ALL)
+baker(external/icu EXCLUDE_FROM_ALL)
 baker(external/lz4/lib/ EXCLUDE_FROM_ALL)
 baker(external/lzma/ EXCLUDE_FROM_ALL)
 baker(external/tinyxml2/ EXCLUDE_FROM_ALL)
@@ -87,6 +91,7 @@ set_property(TARGET art-aconfig-flags-lib-static PROPERTY EXCLUDE_FROM_ALL FALSE
 set_property(TARGET art_libartbase_operator_srcs-gen PROPERTY EXCLUDE_FROM_ALL FALSE)
 set_property(TARGET asm_defines.s PROPERTY EXCLUDE_FROM_ALL FALSE)
 set_property(TARGET libart-shared PROPERTY EXCLUDE_FROM_ALL FALSE)
+set_property(TARGET libjavacore-unit-tests PROPERTY EXCLUDE_FROM_ALL FALSE)
 
 set_tests_properties(boringssl_crypto_test DIRECTORY external/boringssl/ PROPERTIES WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/external/boringssl/src/)
 # FIXME: boringssl_crypto_test fails with libcrypto-shared

--- a/test/manifest.xml
+++ b/test/manifest.xml
@@ -14,8 +14,10 @@
   <project path="external/boringssl" name="platform/external/boringssl" groups="pdk" />
   <project path="external/cpu_features" name="platform/external/cpu_features" groups="pdk" />
   <project path="external/dlmalloc" name="platform/external/dlmalloc" groups="pdk" />
+  <project path="external/fdlibm" name="platform/external/fdlibm" groups="pdk" />
   <project path="external/fmtlib" name="platform/external/fmtlib" groups="pdk" />
   <project path="external/googletest" name="platform/external/googletest" groups="pdk" />
+  <project path="external/icu" name="platform/external/icu" groups="pdk" />
   <project path="external/libcap" name="platform/external/libcap" groups="pdk" />
   <project path="external/lz4" name="platform/external/lz4" groups="pdk" />
   <project path="external/lzma" name="platform/external/lzma" groups="pdk" />
@@ -35,6 +37,7 @@
   <project path="packages/modules/ConfigInfrastructure" name="platform/packages/modules/ConfigInfrastructure" groups="pdk-cw-fs,pdk-fs" />
 
   <project path="art" name="platform/art" groups="pdk" />
+  <project path="libcore" name="platform/libcore" groups="pdk" />
   <project path="libnativehelper" name="platform/libnativehelper" groups="pdk" />
 
 </manifest>

--- a/test/test.list.txt
+++ b/test/test.list.txt
@@ -15,3 +15,5 @@ hashcombine_test
 boringssl_crypto_test
 
 aidl_unittests
+
+libjavacore-unit-tests


### PR DESCRIPTION
Fix sub directories handling when direct sub directories do not contain Android.bp
Fix library handling by exporting all shared libraries by default
Fix baker_include_build handling with list