### PR TITLE
Refactor genrule to use CMake file generation for cmd processing

### DIFF
--- a/baker/definitions/genrule.py
+++ b/baker/definitions/genrule.py
@@ -21,10 +21,11 @@ class GenRule(Module):
         # add_custom_command OUTPUT do not support generator expressions of target, so create a variable
         out = Utils.to_internal_name(name, "OUT")
         lines += self._convert_out_to_cmake(out)
+        command_file = f'${{CMAKE_CURRENT_BINARY_DIR}}/{name}.sh'
+        lines.append(f'file(GENERATE OUTPUT "{command_file}" INPUT "${{CMAKE_SOURCE_DIR}}/cmake/genrule.template.sh" TARGET {gen_target})')
         lines.append(f'''add_custom_command(
                         OUTPUT "$<LIST:TRANSFORM,${{{out}}},PREPEND,${{CMAKE_CURRENT_BINARY_DIR}}/gen/>"
-                        COMMAND ${{CMAKE_SOURCE_DIR}}/cmake/genrule.sh ARGS
-                            --cmd "$<TARGET_PROPERTY:{gen_target},_cmd>"
+                        COMMAND {command_file} ARGS
                             --genDir "${{CMAKE_CURRENT_BINARY_DIR}}/gen/"
                             --outs "${{{out}}}"
                             --srcs "$<PATH:RELATIVE_PATH,$<TARGET_PROPERTY:{gen_target},INTERFACE_SOURCES>,${{CMAKE_CURRENT_SOURCE_DIR}}>"

--- a/cmake/genrule.cmake
+++ b/cmake/genrule.cmake
@@ -19,19 +19,6 @@ function(baker_transform_tool TOOL)
 endfunction(baker_transform_tool)
 
 function(baker_apply_genrule_transform target)
-    # Transform cmd
-    get_target_property(cmd ${target} _cmd)
-    if(cmd STREQUAL "cmd-NOTFOUND")
-        set(cmd "")
-    endif()
-    set(new_cmd "${cmd}")
-    string(REPLACE "$(in)" "$\{in\}" new_cmd "${new_cmd}")
-    string(REPLACE "$(out)" "$\{out\}" new_cmd "${new_cmd}")
-    string(REPLACE "$(genDir)" "$\{genDir\}" new_cmd "${new_cmd}")
-    # FIXME: check how to handle $(location) without arguments
-    string(REPLACE "$(location)" "${CMAKE_CURRENT_SOURCE_DIR}" new_cmd "${new_cmd}")
-    set_property(TARGET ${target} PROPERTY _cmd "${new_cmd}")
-
     # Transform tool_files
     get_target_property(tool_files ${target} _tool_files)
     if(tool_files STREQUAL "tool_files-NOTFOUND")

--- a/cmake/genrule.template.sh
+++ b/cmake/genrule.template.sh
@@ -1,19 +1,20 @@
 #!/bin/env bash
 
-# Parse arguments
-cmd=""
+# Use generator expression to avoid special characters in the cmd
+cmd=$(cat <<'EOF'
+$<TARGET_PROPERTY:_cmd>
+EOF
+)
+
 genDir=""
 outs=()
 srcs=()
 tools=()
 tool_files=()
 
+# Parse arguments
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --cmd)
-            cmd="$2"
-            shift 2
-            ;;
         --genDir)
             genDir="$2"
             shift 2
@@ -68,6 +69,13 @@ if [ -z "$outs" ]; then
     echo "Error: --outs is required"
     exit 1
 fi
+
+# Transform cmd
+# FIXME: check how to handle $(location) without arguments
+cmd="${cmd//\$(location)/.}"
+cmd="${cmd//\$(in)/\$\{in\}}"
+cmd="${cmd//\$(out)/\$\{out\}}"
+cmd="${cmd//\$(genDir)/\$\{genDir\}}"
 
 # Create output directory if it doesn't exist
 mkdir -p "$genDir"


### PR DESCRIPTION
To avoid special characters in the cmd