### PR TITLE
Fix blueprint variable handling in module properties

### DIFF
--- a/baker/definitions/module.py
+++ b/baker/definitions/module.py
@@ -28,7 +28,7 @@ class Module(ABC):
             if not isinstance(value, dict):
                 _key = f"{key}"
                 dicts[_key] = value
-                if isinstance(value, list):
+                if Utils.type_of_expression(value, value) is list:
                     list_keys.add(_key)
                 else:
                     single_keys.add(_key)

--- a/baker/definitions/utils.py
+++ b/baker/definitions/utils.py
@@ -56,7 +56,7 @@ class Utils:
         elif isinstance(expr, ast.MapValue):
             return {key: cls.evaluate_expression(value) for key, value in expr.properties.items()}
         elif isinstance(expr, ast.VariableValue):
-            return cls.evaluate_expression(expr.reference)
+            return expr
         elif isinstance(expr, ast.SelectValue):
             return expr
 


### PR DESCRIPTION
Return VariableValue node directly instead of evaluating reference